### PR TITLE
Enhance activities API with validation and participant management

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,45 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    # Sports related activities
+    "Soccer Team": {
+        "description": "Join the school soccer team and compete in matches",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 22,
+        "participants": ["alex@mergington.edu", "lucas@mergington.edu"]
+    },
+    "Basketball Club": {
+        "description": "Practice basketball skills and play friendly games",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["mia@mergington.edu", "noah@mergington.edu"]
+    },
+    # Artistic activities
+    "Drama Club": {
+        "description": "Act, direct, and produce school plays and performances",
+        "schedule": "Mondays, 4:00 PM - 5:30 PM",
+        "max_participants": 18,
+        "participants": ["ava@mergington.edu", "liam@mergington.edu"]
+    },
+    "Art Workshop": {
+        "description": "Explore painting, drawing, and sculpture techniques",
+        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 16,
+        "participants": ["isabella@mergington.edu", "ethan@mergington.edu"]
+    },
+    # Intellectual activities
+    "Math Olympiad": {
+        "description": "Prepare for math competitions and solve challenging problems",
+        "schedule": "Fridays, 2:00 PM - 3:30 PM",
+        "max_participants": 10,
+        "participants": ["charlotte@mergington.edu", "benjamin@mergington.edu"]
+    },
+    "Science Club": {
+        "description": "Conduct experiments and explore scientific topics",
+        "schedule": "Wednesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 14,
+        "participants": ["amelia@mergington.edu", "jack@mergington.edu"]
     }
 }
 
@@ -61,6 +100,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    # Check if student is already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")
 
     # Add student
     activity["participants"].append(email)

--- a/src/app.py
+++ b/src/app.py
@@ -7,7 +7,7 @@ for extracurricular activities at Mergington High School.
 
 from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
-from fastapi.responses import RedirectResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 import os
 from pathlib import Path
 
@@ -88,7 +88,7 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    return JSONResponse(content=activities, headers={"Cache-Control": "no-store"})
 
 
 @app.post("/activities/{activity_name}/signup")
@@ -108,3 +108,26 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/participants")
+def unregister_participant(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    normalized_email = email.strip().lower()
+    activity = activities[activity_name]
+    original_count = len(activity["participants"])
+
+    activity["participants"] = [
+        participant
+        for participant in activity["participants"]
+        if participant.strip().lower() != normalized_email
+    ]
+
+    removed_count = original_count - len(activity["participants"])
+    if removed_count == 0:
+        raise HTTPException(status_code=404, detail="Participant not found in activity")
+
+    return {"message": f"Removed {email} from {activity_name}"}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -7,11 +7,12 @@ document.addEventListener("DOMContentLoaded", () => {
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
-      const response = await fetch("/activities");
+      const response = await fetch("/activities", { cache: "no-store" });
       const activities = await response.json();
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -19,12 +20,39 @@ document.addEventListener("DOMContentLoaded", () => {
         activityCard.className = "activity-card";
 
         const spotsLeft = details.max_participants - details.participants.length;
+        const participantsListItems = details.participants.length
+          ? details.participants
+              .map(
+                (participant) => `
+                  <li class="participant-item">
+                    <span class="participant-email">${participant}</span>
+                    <button
+                      type="button"
+                      class="participant-delete-btn"
+                      data-activity="${name}"
+                      data-email="${participant}"
+                      aria-label="Remove ${participant} from ${name}"
+                      title="Remove participant"
+                    >
+                      🗑️
+                    </button>
+                  </li>
+                `
+              )
+              .join("")
+          : "<li class=\"empty-participants\">No participants yet</li>";
 
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <p class="participants-title"><strong>Participants:</strong></p>
+            <ul class="participants-list">
+              ${participantsListItems}
+            </ul>
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);
@@ -62,6 +90,7 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        await fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
@@ -78,6 +107,46 @@ document.addEventListener("DOMContentLoaded", () => {
       messageDiv.className = "error";
       messageDiv.classList.remove("hidden");
       console.error("Error signing up:", error);
+    }
+  });
+
+  activitiesList.addEventListener("click", async (event) => {
+    const deleteButton = event.target.closest(".participant-delete-btn");
+    if (!deleteButton) {
+      return;
+    }
+
+    const activity = deleteButton.dataset.activity;
+    const email = deleteButton.dataset.email;
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(activity)}/participants?email=${encodeURIComponent(email)}`,
+        {
+          method: "DELETE",
+        }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        messageDiv.textContent = result.message;
+        messageDiv.className = "success";
+        await fetchActivities();
+      } else {
+        messageDiv.textContent = result.detail || "Could not remove participant";
+        messageDiv.className = "error";
+      }
+
+      messageDiv.classList.remove("hidden");
+      setTimeout(() => {
+        messageDiv.classList.add("hidden");
+      }, 5000);
+    } catch (error) {
+      messageDiv.textContent = "Failed to remove participant. Please try again.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      console.error("Error removing participant:", error);
     }
   });
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,67 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid #e4e8f0;
+}
+
+.participants-title {
+  margin-bottom: 8px;
+  color: #1a237e;
+}
+
+.participants-list {
+  list-style: none;
+  margin-left: 0;
+  padding-left: 0;
+  color: #2f3b52;
+}
+
+.participants-list li {
+  margin-bottom: 6px;
+}
+
+.participant-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  background-color: #eef2ff;
+}
+
+.participant-email {
+  word-break: break-word;
+}
+
+.participant-delete-btn {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 4px;
+  border-radius: 4px;
+}
+
+.participant-delete-btn:hover {
+  background-color: #ffe3e3;
+}
+
+.participant-delete-btn:focus-visible {
+  outline: 2px solid #3949ab;
+  outline-offset: 1px;
+}
+
+.empty-participants {
+  list-style: none;
+  color: #6b7280;
+  font-style: italic;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+from copy import deepcopy
+
+import pytest
+from fastapi.testclient import TestClient
+
+import src.app as app_module
+
+
+@pytest.fixture
+def client():
+    return TestClient(app_module.app)
+
+
+@pytest.fixture(autouse=True)
+def reset_activities_state():
+    baseline_activities = deepcopy(app_module.activities)
+
+    yield
+
+    app_module.activities.clear()
+    app_module.activities.update(deepcopy(baseline_activities))

--- a/tests/test_activities.py
+++ b/tests/test_activities.py
@@ -1,0 +1,128 @@
+import src.app as app_module
+
+
+def test_root_redirects_to_static_index(client):
+    # Arrange
+    root_path = "/"
+
+    # Act
+    response = client.get(root_path, follow_redirects=False)
+
+    # Assert
+    assert response.status_code in (302, 307)
+    assert response.headers["location"] == "/static/index.html"
+
+
+def test_get_activities_returns_expected_structure(client):
+    # Arrange
+    activities_path = "/activities"
+
+    # Act
+    response = client.get(activities_path)
+    payload = response.json()
+
+    # Assert
+    assert response.status_code == 200
+    assert isinstance(payload, dict)
+    assert "Chess Club" in payload
+    assert {"description", "schedule", "max_participants", "participants"}.issubset(payload["Chess Club"].keys())
+    assert isinstance(payload["Chess Club"]["participants"], list)
+
+
+def test_signup_adds_participant_successfully(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "new.student@mergington.edu"
+    before_count = len(app_module.activities[activity_name]["participants"])
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup", params={"email": email})
+    payload = response.json()
+
+    # Assert
+    assert response.status_code == 200
+    assert payload["message"] == f"Signed up {email} for {activity_name}"
+    assert email in app_module.activities[activity_name]["participants"]
+    assert len(app_module.activities[activity_name]["participants"]) == before_count + 1
+
+
+def test_signup_returns_404_for_unknown_activity(client):
+    # Arrange
+    missing_activity = "Nonexistent Club"
+
+    # Act
+    response = client.post(f"/activities/{missing_activity}/signup", params={"email": "student@mergington.edu"})
+    payload = response.json()
+
+    # Assert
+    assert response.status_code == 404
+    assert payload["detail"] == "Activity not found"
+
+
+def test_signup_rejects_duplicate_participant(client):
+    # Arrange
+    activity_name = "Chess Club"
+    existing_email = app_module.activities[activity_name]["participants"][0]
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup", params={"email": existing_email})
+    payload = response.json()
+
+    # Assert
+    assert response.status_code == 400
+    assert payload["detail"] == "Student already signed up for this activity"
+
+
+def test_unregister_removes_participant_case_insensitive(client):
+    # Arrange
+    activity_name = "Chess Club"
+    existing_email = app_module.activities[activity_name]["participants"][0]
+    mixed_case_email = f"  {existing_email.upper()}  "
+
+    # Act
+    response = client.delete(
+        f"/activities/{activity_name}/participants",
+        params={"email": mixed_case_email},
+    )
+    payload = response.json()
+
+    # Assert
+    assert response.status_code == 200
+    assert payload["message"] == f"Removed {mixed_case_email} from {activity_name}"
+    assert all(
+        participant.strip().lower() != existing_email.strip().lower()
+        for participant in app_module.activities[activity_name]["participants"]
+    )
+
+
+def test_unregister_returns_404_for_unknown_activity(client):
+    # Arrange
+    missing_activity = "Nonexistent Club"
+
+    # Act
+    response = client.delete(
+        f"/activities/{missing_activity}/participants",
+        params={"email": "student@mergington.edu"},
+    )
+    payload = response.json()
+
+    # Assert
+    assert response.status_code == 404
+    assert payload["detail"] == "Activity not found"
+
+
+def test_unregister_returns_404_when_participant_missing(client):
+    # Arrange
+    activity_name = "Chess Club"
+    missing_email = "missing.student@mergington.edu"
+
+    # Act
+    response = client.delete(
+        f"/activities/{activity_name}/participants",
+        params={"email": missing_email},
+    )
+    payload = response.json()
+
+    # Assert
+    assert response.status_code == 404
+    assert payload["detail"] == "Participant not found in activity"


### PR DESCRIPTION
This pull request adds support for unregistering participants from activities, improves the frontend to display participants and allow removal, and introduces comprehensive test coverage for the new and existing activity management functionality. It also expands the list of activities and updates API responses for better client-side caching control.

Backend functionality enhancements:

* Added a new `DELETE /activities/{activity_name}/participants` endpoint to allow unregistering participants from activities, with case-insensitive email matching and appropriate error handling.
* Updated the `POST /activities/{activity_name}/signup` endpoint to prevent duplicate sign-ups by checking if the participant already exists.
* Expanded the `activities` dictionary to include sports, artistic, and intellectual activities, each with their own schedules and participant lists.
* Changed the `/activities` endpoint to return a `JSONResponse` with `Cache-Control: no-store` header for improved client-side freshness.

Frontend improvements:

* Updated `src/static/app.js` to display participants for each activity, including a delete button for each participant, and implemented logic to remove participants via the new API endpoint. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3L10-R55) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R113-R152)
* Enhanced the UI in `src/static/styles.css` with styles for participant lists, delete buttons, and empty participant states.

Testing and reliability:

* Added a test fixture in `tests/conftest.py` to reset the activities state between tests, ensuring test isolation and reliability.
* Introduced a comprehensive test suite in `tests/test_activities.py` covering activity retrieval, participant sign-up, duplicate prevention, unregistering (including case-insensitive matching), and error handling for missing activities or participants.